### PR TITLE
Add newline before key in authorized_keys

### DIFF
--- a/templates/post_script/debian.sh
+++ b/templates/post_script/debian.sh
@@ -15,8 +15,8 @@ wget -O $SSH_DIR/authorized_keys https://raw.githubusercontent.com/rcbops/jenkin
 {% if host.ssh_key %}
 # Add specified keypair
 echo "{{host.ssh_key.private_key}}" > $SSH_DIR/id_rsa
-echo "{{host.ssh_key.public_key}}" >> $SSH_DIR/id_rsa.pub
-echo "{{host.ssh_key.public_key}}" >> $SSH_DIR/authorized_keys
+echo "{{host.ssh_key.public_key}}" > $SSH_DIR/id_rsa.pub
+echo -e "\n{{host.ssh_key.public_key}}" >> $SSH_DIR/authorized_keys
 chmod 600 $SSH_DIR/id_rsa
 {% endif %}
 


### PR DESCRIPTION
This script appends a pub ssh key from djeep to authorized keys, however
if authorized keys didn't have a newline at the end, the key would get
  appended to the same line as the previous key and not work.

This patch adds a newline before the key, so that the append will
definitely work regardless of whether authorized_keys had a newline at
EOF or not.

Also overwrite pub key rather than appending to it.