### PR TITLE
Fixing 'bad dhcp-range' error

### DIFF
--- a/templates/etc/dnsmasq.conf
+++ b/templates/etc/dnsmasq.conf
@@ -4,7 +4,7 @@
 dhcp-ignore=tag:!known
 dhcp-ignore-names
 
-dhcp-range={{site.gateway}},static,24h,tag:known
+dhcp-range=tag:known,{{site.gateway}},static,24h
 dhcp-option=3,{{site.gateway}}
 dhcp-option-force=208,f1:00:74:7e
 dhcp-option-force=210,/


### PR DESCRIPTION
When the tag is at the end of the line, the following error gets thrown:

bad dhcp-range at line 7 of /etc/dnsmasq.conf
